### PR TITLE
make regex execution for the chromedriver

### DIFF
--- a/src/main/java/testUI/AndroidUtils/ADBUtils.java
+++ b/src/main/java/testUI/AndroidUtils/ADBUtils.java
@@ -31,10 +31,10 @@ public class ADBUtils {
     private static String emulatorFolder = "/emulator/";
     public static String MAC_CHROME_DRIVER =
             "/usr/local/lib/node_modules/appium/node_modules/appium-chromedriver/chromedriver/mac" +
-                    "/chromedriver";
+                    "/chromedriver*";
     public static String LNX_CHROME_DRIVER =
             "/usr/local/lib/node_modules/appium/node_modules/appium-chromedriver/chromedriver" +
-                    "/linux/chromedriver_64";
+                    "/linux/chromedriver*";
     public static String WIN_CHROME_DRIVER =
             "\\node_modules\\appium\\node_modules\\appium-chromedriver\\chromedriver\\win" +
                     "\\chromedriver.exe";


### PR DESCRIPTION
New appium version downloads the chromedriver with an appended tag about the version:

`/usr/local/lib/node_modules/appium/node_modules/appium-chromedriver/chromedriver/mac/chromedriver_mac64_v89.0.4389.23 `

This pull request fixes that by using regex