### PR TITLE
Validate that screenshot has valid .png extension

### DIFF
--- a/src/main/java/testUI/elements/Element.java
+++ b/src/main/java/testUI/elements/Element.java
@@ -819,8 +819,8 @@ public class Element extends TestUI implements UIElement {
 
     public UIElement saveScreenshot(String path) {
         if (!path.toLowerCase().endsWith(".png")) {
-            Logger.putLogError("Invalid file extension. Only .png files are supported for screenshots.");
-            return null;
+            Logger.putLogWarn("Invalid file extension: Only .png files are supported. Screenshot saved in: "+ Configuration.screenshotPath + path);
+            return getElementObject();
         }
 
         if (!Configuration.automationType.equals(Configuration.DESKTOP_PLATFORM)) {

--- a/src/main/java/testUI/elements/Element.java
+++ b/src/main/java/testUI/elements/Element.java
@@ -817,8 +817,12 @@ public class Element extends TestUI implements UIElement {
         return shouldHave();
     }
 
-
     public UIElement saveScreenshot(String path) {
+        if (!path.toLowerCase().endsWith(".png")) {
+            Logger.putLogError("Invalid file extension. Only .png files are supported for screenshots.");
+            return null;
+        }
+
         if (!Configuration.automationType.equals(Configuration.DESKTOP_PLATFORM)) {
             if (getDrivers().size() != 0) {
                 Configuration.driver = Math.min(Configuration.driver, getDrivers().size());


### PR DESCRIPTION
Implemented a logic to verify whether the argument provided for the screenshot name includes the ".png" extension, as per the details outlined in [Issue #81](https://github.com/testdevlab/TestUI/issues/81).