### PR TITLE
Added method for switching app context

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ In certain scenarios, applications may switch contexts, which can be necessary f
 Utilize the following function to switch the application context:
 
 ```java
-changeAppContext(""); // Pass the application context to switch to
+switchApplicationContext(""); // Pass the application context to switch to
 ```
 
 ## Elements

--- a/README.md
+++ b/README.md
@@ -249,6 +249,14 @@ public class Test {
 }
 ```
 
+## Changing application context
+In certain scenarios, applications may switch contexts, which can be necessary for automation purposes. 
+Utilize the following function to switch the application context:
+
+```java
+changeAppContext(""); // Pass the application context to switch to
+```
+
 ## Elements
 
 Same element can be defined for all the platforms, i.e. same element definition

--- a/src/main/java/testUI/TestUIDriver.java
+++ b/src/main/java/testUI/TestUIDriver.java
@@ -15,6 +15,7 @@ import testUI.elements.UIElement;
 import java.util.*;
 
 import static testUI.UIUtils.*;
+import static testUI.Utils.Logger.putLogInfo;
 
 public class TestUIDriver {
     private static ThreadLocal<List<AppiumDriver>> driver = new ThreadLocal<>();
@@ -234,13 +235,13 @@ public class TestUIDriver {
             for (String contextName : contextNames) {
                 if (contextName.contains(context)) {
                     androidDriver.context(contextName);
-                    System.out.println("Switched to context: " + contextName);
+                    putLogInfo("Switched to context: " + contextName);
                     contextFound = true;
                     break;
                 }
             }
             if (!contextFound) {
-                System.out.println("Provided context is not available");
+                putLogInfo("Provided context is not available");
             }
         } else if (driver instanceof IOSDriver) {
             IOSDriver iosDriver = (IOSDriver) driver;
@@ -249,16 +250,16 @@ public class TestUIDriver {
             for (String contextName : contextNames) {
                 if (contextName.contains(context)) {
                     iosDriver.context(contextName);
-                    System.out.println("Switched to context: " + contextName);
+                    putLogInfo("Switched to context: " + contextName);
                     contextFound = true;
                     break;
                 }
             }
             if (!contextFound) {
-                System.out.println("Provided context is not available");
+                putLogInfo("Provided context is not available");
             }
         } else {
-            System.out.println("Unsupported driver type.");
+            putLogInfo("Unsupported driver type.");
         }
     }
 }

--- a/src/main/java/testUI/TestUIDriver.java
+++ b/src/main/java/testUI/TestUIDriver.java
@@ -12,10 +12,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import testUI.elements.TestUI;
 import testUI.elements.UIElement;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static testUI.UIUtils.*;
 
@@ -224,5 +221,44 @@ public class TestUIDriver {
 
     public static UIElement getTestUIDriver() {
         return TestUI.E("");
+    }
+
+    public static void switchApplicationContext(String context) {
+        AppiumDriver driver = getDriver();
+
+        if (driver instanceof AndroidDriver) {
+            AndroidDriver androidDriver = (AndroidDriver) driver;
+            Set<String> contextNames = androidDriver.getContextHandles();
+
+            boolean contextFound = false;
+            for (String contextName : contextNames) {
+                if (contextName.contains(context)) {
+                    androidDriver.context(contextName);
+                    System.out.println("Switched to context: " + contextName);
+                    contextFound = true;
+                    break;
+                }
+            }
+            if (!contextFound) {
+                System.out.println("Provided context is not available");
+            }
+        } else if (driver instanceof IOSDriver) {
+            IOSDriver iosDriver = (IOSDriver) driver;
+            Set<String> contextNames = iosDriver.getContextHandles();
+            boolean contextFound = false;
+            for (String contextName : contextNames) {
+                if (contextName.contains(context)) {
+                    iosDriver.context(contextName);
+                    System.out.println("Switched to context: " + contextName);
+                    contextFound = true;
+                    break;
+                }
+            }
+            if (!contextFound) {
+                System.out.println("Provided context is not available");
+            }
+        } else {
+            System.out.println("Unsupported driver type.");
+        }
     }
 }

--- a/src/test/java/TestRunners/TestAndroidLocal.java
+++ b/src/test/java/TestRunners/TestAndroidLocal.java
@@ -8,7 +8,6 @@ import testUI.Configuration;
 import testUI.TestUIDriver;
 
 import static testUI.Configuration.ANDROID_PLATFORM;
-import static testUI.Configuration.driver;
 import static testUI.TestUIServer.stop;
 import static testUI.UIOpen.open;
 import static testUI.UIUtils.executeJs;

--- a/src/test/java/TestRunners/TestAndroidLocal.java
+++ b/src/test/java/TestRunners/TestAndroidLocal.java
@@ -8,6 +8,7 @@ import testUI.Configuration;
 import testUI.TestUIDriver;
 
 import static testUI.Configuration.ANDROID_PLATFORM;
+import static testUI.Configuration.driver;
 import static testUI.TestUIServer.stop;
 import static testUI.UIOpen.open;
 import static testUI.UIUtils.executeJs;


### PR DESCRIPTION
Added a new method switchApplicationContext(String context) to facilitate the switching of the application context in Appium-based automation tests. The method supports both Android and iOS platforms and allows testers to seamlessly switch between different contexts during test execution.