### PR TITLE
admit no udid for remote execution

### DIFF
--- a/src/main/java/testUI/AndroidUtils/AndroidCapabilities.java
+++ b/src/main/java/testUI/AndroidUtils/AndroidCapabilities.java
@@ -119,7 +119,7 @@ public class AndroidCapabilities extends Configuration {
                     setDevice(Configuration.UDID, Configuration.androidDeviceName);
                 } else if (!Configuration.UDID.isEmpty()) {
                     setDevice(Configuration.UDID, Configuration.UDID);
-                } else {
+                } else if (Configuration.appiumUrl.isEmpty()) {
                     throw new TestUIException("There is no device available to run the automation!");
                 }
             }

--- a/src/main/java/testUI/IOSUtils/IOSTestUIDriver.java
+++ b/src/main/java/testUI/IOSUtils/IOSTestUIDriver.java
@@ -39,7 +39,7 @@ public class IOSTestUIDriver {
                 attachShutDownHookStopDriver(getDriver());
                 return;
             } catch (Exception e) {
-                putLogError("Could not create driver! retrying...");
+                putLogError("Could not create driver! retrying...\n" + e.getMessage());
                 sleep(500);
                 if (i == 1) {
                     throw new TestUIException(

--- a/src/test/java/TestRunners/TestAndroidLocal.java
+++ b/src/test/java/TestRunners/TestAndroidLocal.java
@@ -42,7 +42,6 @@ public class TestAndroidLocal {
     public void testAndroidBrowser2() {
         Configuration.testUILogLevel = LogLevel.DEBUG;
         Configuration.appiumUrl = "http://localhost:4723/";
-        Configuration.UDID = "emulator-5554";
         open("https://www.google.com");
     }
 }


### PR DESCRIPTION
at the moment, if you specified appiumUrl, it will still check if you had any devices connected to the same computer executing the tests. This will fix that.